### PR TITLE
fix detection, velocity, WC targeting, and same-session reload bugs

### DIFF
--- a/Data/Scripts/DetectionEquipment/Client/ClientMain.cs
+++ b/Data/Scripts/DetectionEquipment/Client/ClientMain.cs
@@ -94,6 +94,7 @@ namespace DetectionEquipment.Client
                 Log.IncreaseIndent();
 
                 CommandHandler.Close();
+                ModderNotification.Close();
                 DetectionHud.Close();
                 WcInteractionManager.Close();
                 RcsTool.Close();

--- a/Data/Scripts/DetectionEquipment/Client/External/WcInteractionManager.cs
+++ b/Data/Scripts/DetectionEquipment/Client/External/WcInteractionManager.cs
@@ -26,6 +26,8 @@ namespace DetectionEquipment.Client.External
 
         public static void Close()
         {
+            // Must unsubscribe, otherwise OnEntityRemove keeps firing after unload and hits a null VisibleTargets (NRE).
+            MyAPIGateway.Entities.OnEntityRemove -= OnEntityRemove;
             VisibleTargets = null;
         }
 

--- a/Data/Scripts/DetectionEquipment/Client/Interface/ModderNotification.cs
+++ b/Data/Scripts/DetectionEquipment/Client/Interface/ModderNotification.cs
@@ -31,6 +31,15 @@ namespace DetectionEquipment.Client.Interface
             _displayTime = 0;
         }
 
+        public static void Close()
+        {
+            // Reset static state and clear any lingering questlog so it doesn't bleed into the menu or the next world load.
+            if (_isDisplaying)
+                MyVisualScriptLogicProvider.SetQuestlogLocal(false, "Detection Equipment - Modder Info");
+            _isDisplaying = false;
+            _displayTime = 1500;
+        }
+
         public static void Update()
         {
             if (!_isDisplaying) return;

--- a/Data/Scripts/DetectionEquipment/Server/SensorBlocks/GridSensorManager.cs
+++ b/Data/Scripts/DetectionEquipment/Server/SensorBlocks/GridSensorManager.cs
@@ -37,6 +37,13 @@ namespace DetectionEquipment.Server.SensorBlocks
 
         public static void ScanTargetsAction(MyCubeGrid mainGrid, BoundingSphereD sphere, List<MyEntity> targets)
         {
+            // Handheld / grid-less weapons (e.g. man-portable WC launchers) can't mount DetEq sensors; give them unfiltered vanilla targeting.
+            if (mainGrid == null)
+            {
+                MyGamePruningStructure.GetAllTopMostEntitiesInSphere(ref sphere, targets);
+                return;
+            }
+
             // Vanilla WC targeting
             if (!GlobalData.OverrideWcTargeting || mainGrid.IsNpcSpawnedGrid)
             {
@@ -46,10 +53,13 @@ namespace DetectionEquipment.Server.SensorBlocks
             }
 
             HashSet<MyEntity> trackedEntitySet = GlobalObjectPools.EntityPool.Pop();
-
+            HashSet<IMyCubeGrid> allAttachedGrids = null;
+            try
+            {
             // Check all aggregators on this grid and subgrids
             GridSensorManager gridSensors;
-            HashSet<IMyCubeGrid> allAttachedGrids = mainGrid.GetGridGroup(GridLinkTypeEnum.Logical).GetGrids(GlobalObjectPools.GridPool.Pop());
+            allAttachedGrids = GlobalObjectPools.GridPool.Pop();
+            mainGrid.GetGridGroup(GridLinkTypeEnum.Logical).GetGrids(allAttachedGrids);
             foreach (var grid in allAttachedGrids)
             {
                 if (ServerMain.I.GridSensorMangers.TryGetValue(grid, out gridSensors))
@@ -106,23 +116,38 @@ namespace DetectionEquipment.Server.SensorBlocks
                 Log.Info("GridSensorManager", $"WC Check Targets {mainGrid.DisplayName} - {targets.Count} found.");
             }
 
-            // return collections to pools, saves on alloc time
-            trackedEntitySet.Clear();
-            GlobalObjectPools.EntityPool.Push(trackedEntitySet);
-            allAttachedGrids.Clear();
-            GlobalObjectPools.GridPool.Push(allAttachedGrids);
-
             ServerNetwork.SendToEveryoneInSync(new WcTargetingPacket(mainGrid, targets), mainGrid.WorldMatrix.Translation);
+            }
+            catch (Exception ex)
+            {
+                // Isolate WC's targeting thread from any exception thrown here.
+                Log.Exception("GridSensorManager", ex);
+            }
+            finally
+            {
+                // Always return pooled collections, even on exception, so they don't leak out of the pool.
+                trackedEntitySet.Clear();
+                GlobalObjectPools.EntityPool.Push(trackedEntitySet);
+                if (allAttachedGrids != null)
+                {
+                    allAttachedGrids.Clear();
+                    GlobalObjectPools.GridPool.Push(allAttachedGrids);
+                }
+            }
         }
 
         public static bool ValidateWeaponTarget(IMyTerminalBlock weapon, int weaponId, MyEntity target)
         {
-            if (!GlobalData.OverrideWcTargeting || weapon.CubeGrid.IsNpcSpawnedGrid)
+            // Handheld / grid-less weapons (e.g. man-portable WC launchers) can't mount DetEq sensors; don't gate them.
+            if (!GlobalData.OverrideWcTargeting || weapon?.CubeGrid == null || weapon.CubeGrid.IsNpcSpawnedGrid)
                 return true;
 
             IMyCubeGrid targetGrid = target as IMyCubeGrid;
             foreach (var aggregatorSet in AggregatorControls.ActiveWeapons)
             {
+                // Skip closed/non-working aggregators (incl. stale entries leaked across reloads) before touching DetectionSet.
+                if (!(aggregatorSet.Key.Block?.IsWorking ?? false))
+                    continue;
                 if (!aggregatorSet.Key.UseAllWeapons && !aggregatorSet.Value.Contains(weapon))
                     continue;
                 var detSet = aggregatorSet.Key.DetectionSet;
@@ -337,14 +362,13 @@ namespace DetectionEquipment.Server.SensorBlocks
             try
             {
                 var cubeBlock = obj.FatBlock;
-                if (cubeBlock != null)
+                if (cubeBlock != null && BlockSensorMap.Remove(cubeBlock)) // only recompute if the removed block was actually a sensor
                 {
                     Sensors.RemoveWhere(sensor => sensor.Block == cubeBlock);
-                    BlockSensorMap.Remove(cubeBlock);
 
                     _hasRadar = Sensors.Any(s => s.Sensor is RadarSensor || s.Sensor is PassiveRadarSensor);
-                    _hasStandardDetection = Sensors.Any(s => s.Definition.MunitionDetection ?? true);
-                    _hasMunitionDetection = Sensors.Any(s => (!s.Definition.MunitionDetection) ?? true);
+                    _hasStandardDetection = Sensors.Any(s => (!s.Definition.MunitionDetection) ?? true);
+                    _hasMunitionDetection = Sensors.Any(s => s.Definition.MunitionDetection ?? true);
                 }
             }
             catch (Exception ex)

--- a/Data/Scripts/DetectionEquipment/Server/SensorBlocks/GridSensorManager.cs
+++ b/Data/Scripts/DetectionEquipment/Server/SensorBlocks/GridSensorManager.cs
@@ -213,6 +213,9 @@ namespace DetectionEquipment.Server.SensorBlocks
         private void UpdateTracks()
         {
             var trackVisBuffer = GlobalObjectPools.VisibilitySetPool.Pop();
+            bool swapped = false;
+            try
+            {
 
             // Standard grid/entity detection
             if (_hasStandardDetection)
@@ -297,8 +300,27 @@ namespace DetectionEquipment.Server.SensorBlocks
                 _trackVisibility.Clear();
                 GlobalObjectPools.VisibilitySetPool.Push(_trackVisibility);
                 _trackVisibility = trackVisBuffer;
+                swapped = true;
             }
-            _isUpdateComplete = true;
+            }
+            catch (Exception ex)
+            {
+                // A tracked entity can be closed mid-scan (e.g. the player deletes a contact), throwing here.
+                // This runs on a parallel thread with no caller catch, so an escaping exception aborts it before
+                // _isUpdateComplete is reset - Update() then never restarts the scan and _trackVisibility freezes
+                // with the now-dead contact still in it, leaving a ghost on the HUD indefinitely.
+                Log.Exception("GridSensorManager", ex);
+                if (!swapped) // never swapped in: return the unused buffer instead of leaking it
+                {
+                    trackVisBuffer.Clear();
+                    GlobalObjectPools.VisibilitySetPool.Push(trackVisBuffer);
+                }
+                _combineBuffer.Clear(); // drop partial combine state so the next cycle starts clean
+            }
+            finally
+            {
+                _isUpdateComplete = true; // always allow the next update cycle to run
+            }
         }
 
         public void Close()

--- a/Data/Scripts/DetectionEquipment/Server/Sensors/AntennaSensor.cs
+++ b/Data/Scripts/DetectionEquipment/Server/Sensors/AntennaSensor.cs
@@ -63,13 +63,13 @@ namespace DetectionEquipment.Server.Sensors
                 return false;
             }
 
-            double receiverAreaAtAngle = Aperture <= Math.PI && Definition.RadarProperties.AccountForRadarAngle ? Definition.RadarProperties.ReceiverArea * targetAngle : Definition.RadarProperties.ReceiverArea;
+            double receiverAreaAtAngle = Aperture <= Math.PI && Definition.RadarProperties.AccountForRadarAngle ? Definition.RadarProperties.ReceiverArea * Math.Cos(targetAngle) : Definition.RadarProperties.ReceiverArea;
 
             const double inherentNoise = 3;
             var sensorSignal = MathUtils.ToDecibels(
                 4 * Math.PI * receiverAreaAtAngle * track.CommsVisibility(Position) // antenna range is linearly proportional to power draw and that's silly.
                 /
-                (targetRange + extraDistance) * (inherentNoise + CountermeasureNoise)
+                ((targetRange + extraDistance) * (inherentNoise + CountermeasureNoise))
                 );
 
             if (double.IsNegativeInfinity(sensorSignal) || sensorSignal < 15)

--- a/Data/Scripts/DetectionEquipment/Server/Sensors/PassiveRadarSensor.cs
+++ b/Data/Scripts/DetectionEquipment/Server/Sensors/PassiveRadarSensor.cs
@@ -87,7 +87,8 @@ namespace DetectionEquipment.Server.Sensors
                     : Definition.RadarProperties.ReceiverArea;
 
                 // https://www.ll.mit.edu/sites/default/files/outreach/doc/2018-07/lecture%202.pdf
-                signalToNoiseRatio = MathUtils.ToDecibels((Definition.MaxPowerDraw * Definition.RadarProperties.PowerEfficiencyModifier * gain * crossSection) / (4 * Math.PI * effectiveRange*effectiveRange * 1.38E-23 * 950 * Definition.RadarProperties.Bandwidth));
+                // Received signal depends on the EMITTER's radiated power, not this passive receiver's (whose MaxPowerDraw is -1, the "no transmit" sentinel).
+                signalToNoiseRatio = MathUtils.ToDecibels((sensor.Definition.MaxPowerDraw * sensor.Definition.RadarProperties.PowerEfficiencyModifier * gain * crossSection) / (4 * Math.PI * effectiveRange*effectiveRange * 1.38E-23 * 950 * Definition.RadarProperties.Bandwidth));
             }
 
             if (signalToNoiseRatio < 0)

--- a/Data/Scripts/DetectionEquipment/Shared/BlockLogic/Aggregator/AggregatorBlock.cs
+++ b/Data/Scripts/DetectionEquipment/Shared/BlockLogic/Aggregator/AggregatorBlock.cs
@@ -119,6 +119,7 @@ namespace DetectionEquipment.Shared.BlockLogic.Aggregator
             return false;
         }
 
+        private readonly object _detectionSetLock = new object();
         private int _lastDetectionSetUpdate = -1;
         private HashSet<WorldDetectionInfo> _lastDetectionSet = new HashSet<WorldDetectionInfo>(0);
         /// <summary>
@@ -127,6 +128,12 @@ namespace DetectionEquipment.Shared.BlockLogic.Aggregator
         /// <returns></returns>
         private HashSet<WorldDetectionInfo> UpdateAggregatedDetections()
         {
+            lock (_detectionSetLock)
+            {
+            // Another thread may have already rebuilt this frame while we waited on the lock.
+            if (_lastDetectionSetUpdate + 1 > MyAPIGateway.Session.GameplayFrameCounter)
+                return _lastDetectionSet;
+
             var infosCache = ControlBlockManager.I.GroupInfoBuffer.Pop();
 
             lock (_bufferDetections)
@@ -171,19 +178,16 @@ namespace DetectionEquipment.Shared.BlockLogic.Aggregator
                     
             }
 
-            lock (_lastDetectionSet)
-            {
-                _lastDetectionSetUpdate = MyAPIGateway.Session.GameplayFrameCounter;
-                _lastDetectionSet.Clear();
-                foreach (var info in AggregateInfos(infosCache))
-                {
-                    var item = info;
-                    _lastDetectionSet.Add(item);
-                }
+            // Build a fresh set and swap it in, so readers holding the previous reference never observe a half-cleared set.
+            var newSet = new HashSet<WorldDetectionInfo>();
+            foreach (var info in AggregateInfos(infosCache))
+                newSet.Add(info);
 
-                ControlBlockManager.I.GroupInfoBuffer.Push(infosCache);
+            ControlBlockManager.I.GroupInfoBuffer.Push(infosCache);
 
-                return _lastDetectionSet;
+            _lastDetectionSet = newSet;
+            _lastDetectionSetUpdate = MyAPIGateway.Session.GameplayFrameCounter;
+            return _lastDetectionSet;
             }
         }
 
@@ -222,6 +226,12 @@ namespace DetectionEquipment.Shared.BlockLogic.Aggregator
             DetectionCache.Clear();
             _parallelCache.Clear();
             GridSensors?.Aggregators.Remove(this);
+
+            // Remove from the static control registries, otherwise dead aggregators leak across block close and world reload
+            // and poison WC targeting (ValidateWeaponTarget iterates ActiveWeapons).
+            AggregatorControls.ActiveWeapons.Remove(this);
+            AggregatorControls.ActiveSensors.Remove(this);
+            AggregatorControls.ClientActiveSensors.Remove(this);
 
             DatalinkManager.UnregisterAggregator(this);
         }

--- a/Data/Scripts/DetectionEquipment/Shared/BlockLogic/Aggregator/AggregatorBlock_Logic.cs
+++ b/Data/Scripts/DetectionEquipment/Shared/BlockLogic/Aggregator/AggregatorBlock_Logic.cs
@@ -61,9 +61,8 @@ namespace DetectionEquipment.Shared.BlockLogic.Aggregator
                     for (int i = 0; i < velocities.Length; i++)
                     {
                         if (GlobalData.DebugLevel > 1)
-                            DebugDraw.AddLine(toCombine[i].SnapshotPosition, toCombine[i+1].SnapshotPosition, Color.White * ((float)i/velocities.Length), 0); // Position delta indicator
-                        // Use the per-tick frozen snapshot, not Position (which reads the live entity center and would erase motion).
-                        velocities[i] = (toCombine[i + 1].SnapshotPosition - toCombine[i].SnapshotPosition) * 60;
+                            DebugDraw.AddLine(toCombine[i].Position, toCombine[i+1].Position, Color.White * ((float)i/velocities.Length), 0); // Position delta indicator
+                        velocities[i] = (toCombine[i + 1].Position - toCombine[i].Position) * 60;
                         averageVelocity += velocities[i];
                     }
                     averageVelocity /= velocities.Length;

--- a/Data/Scripts/DetectionEquipment/Shared/BlockLogic/Aggregator/AggregatorBlock_Logic.cs
+++ b/Data/Scripts/DetectionEquipment/Shared/BlockLogic/Aggregator/AggregatorBlock_Logic.cs
@@ -61,8 +61,9 @@ namespace DetectionEquipment.Shared.BlockLogic.Aggregator
                     for (int i = 0; i < velocities.Length; i++)
                     {
                         if (GlobalData.DebugLevel > 1)
-                            DebugDraw.AddLine(toCombine[i].Position, toCombine[i+1].Position, Color.White * ((float)i/velocities.Length), 0); // Position delta indicator
-                        velocities[i] = (toCombine[i + 1].Position - toCombine[i].Position) * 60;
+                            DebugDraw.AddLine(toCombine[i].SnapshotPosition, toCombine[i+1].SnapshotPosition, Color.White * ((float)i/velocities.Length), 0); // Position delta indicator
+                        // Use the per-tick frozen snapshot, not Position (which reads the live entity center and would erase motion).
+                        velocities[i] = (toCombine[i + 1].SnapshotPosition - toCombine[i].SnapshotPosition) * 60;
                         averageVelocity += velocities[i];
                     }
                     averageVelocity /= velocities.Length;

--- a/Data/Scripts/DetectionEquipment/Shared/BlockLogic/Aggregator/AggregatorControls.cs
+++ b/Data/Scripts/DetectionEquipment/Shared/BlockLogic/Aggregator/AggregatorControls.cs
@@ -26,7 +26,11 @@ namespace DetectionEquipment.Shared.BlockLogic.Aggregator
         public override void DoOnce(IControlBlockBase thisLogic)
         {
             if (!IsDone)
+            {
                 ActiveSensors.Clear();
+                ActiveWeapons.Clear();
+                ClientActiveSensors.Clear();
+            }
             base.DoOnce(thisLogic);
             ActiveSensors[(AggregatorBlock)thisLogic] = new HashSet<BlockSensor>();
             ActiveWeapons[(AggregatorBlock)thisLogic] = new HashSet<IMyTerminalBlock>();

--- a/Data/Scripts/DetectionEquipment/Shared/BlockLogic/ControlBlockBase.cs
+++ b/Data/Scripts/DetectionEquipment/Shared/BlockLogic/ControlBlockBase.cs
@@ -62,7 +62,8 @@ namespace DetectionEquipment.Shared.BlockLogic
 
         public virtual void MarkForClose(IMyEntity entity)
         {
-            ControlBlockManager.I.Blocks.Remove(Block as MyCubeBlock);
+            // Null-guard: MarkForClose can fire from the engine after ControlBlockManager has already unloaded.
+            ControlBlockManager.I?.Blocks?.Remove(Block as MyCubeBlock);
             OnClose?.Invoke();
         }
     }

--- a/Data/Scripts/DetectionEquipment/Shared/BlockLogic/ControlBlockManager.cs
+++ b/Data/Scripts/DetectionEquipment/Shared/BlockLogic/ControlBlockManager.cs
@@ -15,7 +15,9 @@ namespace DetectionEquipment.Shared.BlockLogic
     {
         public static ControlBlockManager I;
         public Dictionary<IMyCubeBlock, IControlBlockBase> Blocks = new Dictionary<IMyCubeBlock, IControlBlockBase>(); // assume only one IControlBlockBase is ever present on a given block.
-        public Dictionary<string, IBlockSelectControl> BlockControls = new Dictionary<string, IBlockSelectControl>();
+        // Static so control registrations survive a same-session world reload, matching the lifetime of the terminal
+        // controls themselves (which are only created once per process via TerminalControlAdder._doneIds).
+        public static Dictionary<string, IBlockSelectControl> BlockControls = new Dictionary<string, IBlockSelectControl>();
 
         public long TerminalSelectedBlock = 0;
 
@@ -123,6 +125,26 @@ namespace DetectionEquipment.Shared.BlockLogic
         internal static void Unload()
         {
             SerializationNotifier.OnSerialize -= I.OnSerialize;
+            MyAPIGateway.Entities.OnEntityAdd -= OnEntityAdd;
+
+            // Close every block logic so its MarkForClose cleanup runs (datalink unregister, GridSensors removal,
+            // static control-registry removal). Otherwise dead logics leak across a same-session reload and poison
+            // things like WC targeting. Iterate a copy because MarkForClose removes from Blocks.
+            if (I.Blocks != null)
+            {
+                foreach (var logic in new List<IControlBlockBase>(I.Blocks.Values))
+                {
+                    try
+                    {
+                        logic.MarkForClose(logic.CubeBlock);
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Exception("ControlBlockManager", ex);
+                    }
+                }
+            }
+
             I.Blocks = null;
             if (!MyAPIGateway.Utilities.IsDedicated)
                 MyAPIGateway.TerminalControls.CustomControlGetter -= CustomControlGetter;

--- a/Data/Scripts/DetectionEquipment/Shared/BlockLogic/GenericControls/BlockSelectControl.cs
+++ b/Data/Scripts/DetectionEquipment/Shared/BlockLogic/GenericControls/BlockSelectControl.cs
@@ -57,7 +57,7 @@ namespace DetectionEquipment.Shared.BlockLogic.GenericControls
             _onListChanged = onListChanged;
             _useSubgrids = useSubgrids;
             _id = controlAdder.IdPrefix + id;
-            ControlBlockManager.I.BlockControls[_id] = this;
+            ControlBlockManager.BlockControls[_id] = this;
         }
 
         public void UpdateSelectedFromPersistent(IControlBlockBase logic, long[] selectedPersistent)
@@ -331,7 +331,7 @@ namespace DetectionEquipment.Shared.BlockLogic.GenericControls
             IBlockSelectControl control;
             //Log.Info("BlockSelectControl", $"Packet received {BlockId} {Selected?.Length ?? -1}\n" +
             //                               $"{block != null}, {block != null && ControlBlockManager.I.Blocks.ContainsKey((MyCubeBlock)block)}, {ControlBlockManager.I.BlockControls.ContainsKey(ControlId)}");
-            if (block == null || !ControlBlockManager.I.Blocks.TryGetValue((MyCubeBlock)block, out controller) || !ControlBlockManager.I.BlockControls.TryGetValue(ControlId, out control))
+            if (block == null || !ControlBlockManager.I.Blocks.TryGetValue((MyCubeBlock)block, out controller) || !ControlBlockManager.BlockControls.TryGetValue(ControlId, out control))
                 return;
             control.UpdateSelected(controller, Selected, true);
 

--- a/Data/Scripts/DetectionEquipment/Shared/SharedMain.cs
+++ b/Data/Scripts/DetectionEquipment/Shared/SharedMain.cs
@@ -97,8 +97,8 @@ namespace DetectionEquipment.Shared
                 ApiManager.Unload();
                 TrackingUtils.Unload();
                 IffHelper.Unload();
+                ControlBlockManager.Unload(); // closes block logics; must run before DatalinkManager (aggregator close unregisters from it)
                 DatalinkManager.Unload();
-                ControlBlockManager.Unload();
                 DefinitionManager.Unload();
                 PersistentBlockIdHelper.Unload();
                 ObjectPackager.Unload();

--- a/Data/Scripts/DetectionEquipment/Shared/Structs/WorldDetectionInfo.cs
+++ b/Data/Scripts/DetectionEquipment/Shared/Structs/WorldDetectionInfo.cs
@@ -22,13 +22,6 @@ namespace DetectionEquipment.Shared.Structs
         public MyRelationsBetweenPlayers? Relations;
         public MyEntity Entity;
 
-        /// <summary>
-        /// Absolute world position captured at the moment this detection was created. Unlike <see cref="Position"/>
-        /// (which reads the live entity center every access), this is frozen, so velocity can be estimated from the
-        /// delta between snapshots taken on different ticks.
-        /// </summary>
-        public Vector3D SnapshotPosition;
-
         public Vector3D Position => Entity == null ? PositionOffset : PositionOffset + Entity.PositionComp.WorldAABB.Center;
         public double SumError => MaxRangeError + MaxBearingError;
 
@@ -53,7 +46,6 @@ namespace DetectionEquipment.Shared.Structs
             //wInfo.Error += info.MaxRangeError * info.MaxRangeError; // normal error
             //wInfo.Error = Math.Sqrt(wInfo.Error);
             wInfo.Relations = aggregator?.GetInfoRelations(wInfo);
-            wInfo.SnapshotPosition = wInfo.Position; // freeze the absolute position at detection time for velocity estimation
 
             return wInfo;
         }
@@ -73,7 +65,6 @@ namespace DetectionEquipment.Shared.Structs
                 IffCodes = info.IffCodes,
                 Relations = info.Relations,
                 Entity = info.Entity,
-                SnapshotPosition = info.SnapshotPosition,
             };
         }
 
@@ -141,7 +132,6 @@ namespace DetectionEquipment.Shared.Structs
                 VelocityVariance = velocityCount > 0 ? varianceSum / velocityCount : (double?)null,
             };
             wInfo.Relations = aggregator?.GetInfoRelations(wInfo);
-            wInfo.SnapshotPosition = wInfo.Position; // freeze the absolute position at detection time for velocity estimation
 
             return wInfo;
         }

--- a/Data/Scripts/DetectionEquipment/Shared/Structs/WorldDetectionInfo.cs
+++ b/Data/Scripts/DetectionEquipment/Shared/Structs/WorldDetectionInfo.cs
@@ -22,6 +22,13 @@ namespace DetectionEquipment.Shared.Structs
         public MyRelationsBetweenPlayers? Relations;
         public MyEntity Entity;
 
+        /// <summary>
+        /// Absolute world position captured at the moment this detection was created. Unlike <see cref="Position"/>
+        /// (which reads the live entity center every access), this is frozen, so velocity can be estimated from the
+        /// delta between snapshots taken on different ticks.
+        /// </summary>
+        public Vector3D SnapshotPosition;
+
         public Vector3D Position => Entity == null ? PositionOffset : PositionOffset + Entity.PositionComp.WorldAABB.Center;
         public double SumError => MaxRangeError + MaxBearingError;
 
@@ -46,6 +53,7 @@ namespace DetectionEquipment.Shared.Structs
             //wInfo.Error += info.MaxRangeError * info.MaxRangeError; // normal error
             //wInfo.Error = Math.Sqrt(wInfo.Error);
             wInfo.Relations = aggregator?.GetInfoRelations(wInfo);
+            wInfo.SnapshotPosition = wInfo.Position; // freeze the absolute position at detection time for velocity estimation
 
             return wInfo;
         }
@@ -65,6 +73,7 @@ namespace DetectionEquipment.Shared.Structs
                 IffCodes = info.IffCodes,
                 Relations = info.Relations,
                 Entity = info.Entity,
+                SnapshotPosition = info.SnapshotPosition,
             };
         }
 
@@ -92,6 +101,9 @@ namespace DetectionEquipment.Shared.Structs
             MyEntity entity = null;
             long entId = -1;
             var allCodes = new List<string>();
+            Vector3D velocitySum = Vector3D.Zero;
+            double varianceSum = 0;
+            int velocityCount = 0;
             foreach (var info in args)
             {
                 if (info.Entity != null)
@@ -102,6 +114,14 @@ namespace DetectionEquipment.Shared.Structs
                     if (!allCodes.Contains(code))
                         allCodes.Add(code);
                 proposedType |= info.DetectionType;
+
+                // Carry velocity estimates through aggregation; otherwise multi-sensor/datalink tracks lose velocity (display NOLOC).
+                if (info.Velocity != null)
+                {
+                    velocitySum += info.Velocity.Value;
+                    varianceSum += info.VelocityVariance ?? 0;
+                    velocityCount++;
+                }
             }
 
             double minRangeError, minBearingError, averageCrossSection;
@@ -117,8 +137,11 @@ namespace DetectionEquipment.Shared.Structs
                 MaxBearingError = minBearingError,
                 DetectionType = proposedType,
                 IffCodes = allCodes.ToArray(),
+                Velocity = velocityCount > 0 ? velocitySum / velocityCount : (Vector3D?)null,
+                VelocityVariance = velocityCount > 0 ? varianceSum / velocityCount : (double?)null,
             };
             wInfo.Relations = aggregator?.GetInfoRelations(wInfo);
+            wInfo.SnapshotPosition = wInfo.Position; // freeze the absolute position at detection time for velocity estimation
 
             return wInfo;
         }


### PR DESCRIPTION
Detection / sensors:
- GridSensorManager: OnBlockRemoved recomputed _hasStandardDetection/ _hasMunitionDetection with swapped conditions, so destroying any functional block flipped standard detection off and wiped all contacts. Restore to match OnBlockAdded; also gate the recompute on the block actually being a sensor.
- PassiveRadarSensor: SNR used the receiver's own MaxPowerDraw (-1) and never returned a detection; use the emitting radar's transmit power.
- AntennaSensor: missing parentheses made noise multiply (jamming improved detection) instead of divide; raw targetAngle zeroed the signal at boresight. Use a parenthesized denominator and cos(angle).

Velocity:
- WorldDetectionInfo.Average dropped Velocity/VelocityVariance, so aggregated tracks showed NOLOC; carry them through.
- Velocity was derived from Position (live entity center), collapsing every cached frame to the same point (always 0 m/s). Add a SnapshotPosition frozen at detection time and estimate from that.

WeaponCore targeting:
- ScanTargetsAction/ValidateWeaponTarget deny-all'd or NRE'd grid-less (handheld) weapons under the targeting override; fall back to vanilla.
- ScanTargetsAction now exception-isolated with guaranteed pool return.
- AggregatorBlock.DetectionSet rebuilt in place; rebuild into a fresh set under a dedicated lock and swap atomically to avoid reader races.

Same-session reload / lifecycle:
- ControlBlockManager.Unload now closes every block logic so MarkForClose cleanup runs; unsubscribes OnEntityAdd; BlockControls made static so registrations survive a reload. AggregatorBlock.MarkForClose removes itself from the static control registries.
- WcInteractionManager unsubscribes OnEntityRemove on close (was NRE'ing a nulled VisibleTargets afterward).
- ModderNotification.Close resets static state / clears the questlog.
- ControlBlockBase.MarkForClose null-guarded for post-unload calls.
- SharedMain unloads ControlBlockManager before DatalinkManager so aggregator close can still unregister from the datalink.

Partially tested, completion of testing pending...